### PR TITLE
일별 주문 금액 집계 Step 개발

### DIFF
--- a/src/main/java/fastcampus/spring/batch/springbatchlevel/OrderStatistics.java
+++ b/src/main/java/fastcampus/spring/batch/springbatchlevel/OrderStatistics.java
@@ -1,0 +1,20 @@
+package fastcampus.spring.batch.springbatchlevel;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class OrderStatistics {
+
+    private String amount;
+
+    private LocalDate date;
+
+    @Builder
+    private OrderStatistics(String amount, LocalDate date) {
+        this.amount = amount;
+        this.date = date;
+    }
+}

--- a/src/main/java/fastcampus/spring/batch/springbatchlevel/UserConfiguration.java
+++ b/src/main/java/fastcampus/spring/batch/springbatchlevel/UserConfiguration.java
@@ -4,35 +4,55 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
 import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
 import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.batch.item.file.FlatFileItemWriter;
+import org.springframework.batch.item.file.builder.FlatFileItemWriterBuilder;
+import org.springframework.batch.item.file.transform.BeanWrapperFieldExtractor;
+import org.springframework.batch.item.file.transform.DelimitedLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.FileSystemResource;
 
 import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @Slf4j
 public class UserConfiguration {
 
+    private final int CHUNK = 100;
     private final JobBuilderFactory jobBuilderFactory;
     private final StepBuilderFactory stepBuilderFactory;
     private final UserRepository userRepository;
     private final EntityManagerFactory entityManagerFactory;
+    private final DataSource dataSource;
 
     public UserConfiguration(JobBuilderFactory jobBuilderFactory,
                              StepBuilderFactory stepBuilderFactory,
                              UserRepository userRepository,
-                             EntityManagerFactory entityManagerFactory) {
+                             EntityManagerFactory entityManagerFactory,
+                             DataSource dataSource) {
         this.jobBuilderFactory = jobBuilderFactory;
         this.stepBuilderFactory = stepBuilderFactory;
         this.userRepository = userRepository;
         this.entityManagerFactory = entityManagerFactory;
+        this.dataSource = dataSource;
     }
 
     @Bean
@@ -41,8 +61,76 @@ public class UserConfiguration {
                 .incrementer(new RunIdIncrementer())
                 .start(this.saveUserStep())
                 .next(this.userLevelUpStep())
+                .next(this.orderStatisticsStep(null))
                 .listener(new LevelUpJobExecutionListener(userRepository))
                 .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step orderStatisticsStep(@Value("#{jobParameters[date]}") String date) throws Exception {
+        return this.stepBuilderFactory.get("orderStatisticsStep")
+                .<OrderStatistics, OrderStatistics>chunk(CHUNK)
+                .reader(orderStatisticsItemReader(date))
+                .writer(orderStatisticsItemWriter(date))
+                .build();
+
+    }
+
+    private ItemWriter<? super OrderStatistics> orderStatisticsItemWriter(String date) throws Exception{
+        YearMonth yearMonth = YearMonth.parse(date);
+
+        String fileName = yearMonth.getYear() + "년_" + yearMonth.getMonthValue() + "월_일별_주문_금액.csv";
+
+        BeanWrapperFieldExtractor<OrderStatistics> fieldExtractor = new BeanWrapperFieldExtractor<>();
+        fieldExtractor.setNames(new String[] {"amount", "date"});
+
+        DelimitedLineAggregator<OrderStatistics> lineAggregator = new DelimitedLineAggregator<>();
+        lineAggregator.setDelimiter(",");
+        lineAggregator.setFieldExtractor(fieldExtractor);
+
+        FlatFileItemWriter<OrderStatistics> itemWriter = new FlatFileItemWriterBuilder<OrderStatistics>()
+                .resource(new FileSystemResource("output/" + fileName))
+                .lineAggregator(lineAggregator)
+                .name("orderStatisticsItemWriter")
+                .encoding("UTF-8")
+                .headerCallback(writer -> writer.write("total_amount,date"))
+                .build();
+
+        itemWriter.afterPropertiesSet();
+
+        return itemWriter;
+    }
+
+    private ItemReader<? extends OrderStatistics> orderStatisticsItemReader(String date) throws Exception {
+        YearMonth yearMonth = YearMonth.parse(date);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("startDate", yearMonth.atDay(1));
+        parameters.put("endDate", yearMonth.atEndOfMonth());
+
+        Map<String, Order> sortKey = new HashMap<>();
+        sortKey.put("created_date", Order.ASCENDING);
+
+        JdbcPagingItemReader<OrderStatistics> itemReader = new JdbcPagingItemReaderBuilder<OrderStatistics>()
+                .dataSource(this.dataSource)
+                .rowMapper((resultSet, i) -> OrderStatistics.builder()
+                        .amount(resultSet.getString(1))
+                        .date(LocalDate.parse(resultSet.getString(2), DateTimeFormatter.ISO_DATE))
+                        .build())
+                .pageSize(CHUNK)
+                .name("orderStatisticsItemReader")
+                .selectClause("sum(amount), created_date")
+                .fromClause("orders")
+                .whereClause("created_date >= :startDate and created_date <= :endDate")
+                .groupClause("created_date")
+                .parameterValues(parameters)
+                .sortKeys(sortKey)
+                .build();
+
+        itemReader.afterPropertiesSet();
+
+        return itemReader;
     }
 
     @Bean
@@ -55,7 +143,7 @@ public class UserConfiguration {
     @Bean
     public Step userLevelUpStep() throws Exception {
         return this.stepBuilderFactory.get("userLevelUpStep")
-                .<User, User>chunk(100)
+                .<User, User>chunk(CHUNK)
                 .reader(itemReader())
                 .processor(itemProcessor())
                 .writer(itemWriter())
@@ -66,7 +154,7 @@ public class UserConfiguration {
         JpaPagingItemReader<User> itemReader = new JpaPagingItemReaderBuilder<User>()
                 .queryString("select u from User u")
                 .entityManagerFactory(entityManagerFactory)
-                .pageSize(100)
+                .pageSize(CHUNK)
                 .name("userItemReader")
                 .build();
 


### PR DESCRIPTION
주문 금액 집계 엔티티 생성
-----------
### OrderStatistics.java
>- 총 금액 : `amount`
>- 날짜 : `date` 

일별 주문 금액 집계 Step 구현
-------------
### UserConfiguration.java
>- orderStatisticsStep 구현
>    - chunk : `CHUNK`
>        - `CHUNK=100`
>    - reader : `orderStatisticsItemReader`
>        - `﻿JdbcPagingItemReader`로 orders 조회
>        - 파라미터 값을 기준으로 금액 합계와 날짜 조회
>    - writer : `orderStatisticsItemWriter`
>        - output에 `YYYY년_MM월_주문_금액.csv` 파일 생성

closes #15 